### PR TITLE
Fix Windows/MinGW build and load in Rack 2 (error 127, install path, simde, M_PI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ target_compile_options(VCVRackMcpServer PRIVATE
 
 # Platform-specific optimization flags
 if(RACK_ARCH STREQUAL "lin-x64" OR RACK_ARCH STREQUAL "win-x64")
-  target_compile_options(VCVRackMcpServer PRIVATE -march=nocona)  # SSE4.2 baseline for x64
+  target_compile_options(VCVRackMcpServer PRIVATE -march=nehalem)  # Rack 2 x64 standard (SSE4.2 + SSSE3, required by bundled simde)
 elseif(RACK_ARCH STREQUAL "mac-x64")
   target_compile_options(VCVRackMcpServer PRIVATE -march=nehalem)  # SSE4.2 for Intel Mac
 endif()
@@ -178,6 +178,7 @@ endif()
 string(REPLACE "-" "_" RACK_ARCH_MACRO "${RACK_ARCH}")
 target_compile_definitions(VCVRackMcpServer PRIVATE
   ARCH_${RACK_ARCH_MACRO}   # lets source code #ifdef on arch if needed
+  _USE_MATH_DEFINES         # MinGW <cmath> hides M_PI/M_SQRT2 under strict -std=c++17 without this
 )
 
 if(APPLE)
@@ -210,6 +211,18 @@ elseif(UNIX)
   )
 elseif(WIN32)
   target_link_libraries(VCVRackMcpServer PRIVATE ws2_32 mswsock)
+  # Statically link the MinGW C++ runtime. Rack's install dir is on the DLL search
+  # path and ships OLDER libstdc++-6/libgcc/libwinpthread DLLs; a plugin built with a
+  # newer toolchain that imports those dynamically fails to load (error 127 — proc not
+  # found). Static linking removes the dependency entirely. (Matches Rack's plugin.mk.)
+  #
+  # Use the full -static driver flag: it links libgcc, libstdc++ AND libwinpthread
+  # statically in one shot. The targeted -static-libgcc/-static-libstdc++ +
+  # -Wl,-Bstatic -lwinpthread approach leaks libwinpthread-1.dll, because the
+  # implicit libstdc++ re-pulls pthread symbols under the trailing -Bdynamic.
+  # System DLLs (kernel32, msvcrt, ws2_32, libRack import lib) stay dynamic —
+  # MinGW links those normally regardless of -static.
+  target_link_options(VCVRackMcpServer PRIVATE -static)
   # Windows: link the Rack import library if the SDK provides one.
   if(EXISTS "${RACK_DIR}/Rack.lib")
     target_link_libraries(VCVRackMcpServer PRIVATE "${RACK_DIR}/Rack.lib")
@@ -223,10 +236,15 @@ endif()
 if(APPLE)
   set(RACK_PLUGINS_DIR "$ENV{HOME}/Library/Application Support/Rack2/plugins-${RACK_ARCH}")
 elseif(WIN32)
-  set(RACK_PLUGINS_DIR "$ENV{APPDATA}/Rack2/plugins")
+  # Rack 2 reads user plugins from %LOCALAPPDATA%\Rack2\plugins-<arch> (NOT %APPDATA%/Roaming).
+  set(RACK_PLUGINS_DIR "$ENV{LOCALAPPDATA}/Rack2/plugins-${RACK_ARCH}")
 else()
   set(RACK_PLUGINS_DIR "$ENV{HOME}/.Rack2/plugins")
 endif()
+
+# Normalize to forward slashes — Windows env paths (e.g. %APPDATA%) contain backslashes
+# that install() DESTINATION misreads as escapes (e.g. "\Users" -> invalid '\U').
+file(TO_CMAKE_PATH "${RACK_PLUGINS_DIR}" RACK_PLUGINS_DIR)
 
 set(PLUGIN_INSTALL_DIR ${RACK_PLUGINS_DIR}/VCVRackMcpServer)
 


### PR DESCRIPTION
Builds and loads the plugin on Windows using the MSYS2 mingw64 toolchain. Five CMake defects each blocked build or load; fixed in `CMakeLists.txt` (1 file, +20/-2).

### Fixes
1. **`-static` runtime link** — the plugin imported `libstdc++-6.dll`/`libgcc_s_seh-1.dll`/`libwinpthread-1.dll`. Rack's install dir is on the DLL search path and ships *older* copies, so the dynamically-linked plugin fails to load with **`Failed to load library plugin.dll: code 127`** (procedure not found). Using the full `-static` driver flag links the whole MinGW runtime in one shot. (The narrower `-static-libgcc -static-libstdc++` + `-Wl,-Bstatic -lwinpthread` form still leaks `libwinpthread-1.dll`, because the implicit libstdc++ re-pulls pthread under the trailing `-Bdynamic`.) System DLLs (kernel32, msvcrt, ws2_32, libRack import lib) stay dynamic.
2. **Install to `%LOCALAPPDATA%\Rack2\plugins-<arch>`** (was `%APPDATA%\Roaming\Rack2\plugins`) — Rack 2 reads user plugins from LocalAppData; the wrong dir means the plugin is silently never scanned.
3. **`-march=nehalem`** (was `nocona`) for win/lin x64 — nocona lacks SSSE3, so the SDK's bundled simde headers emit redefinitions. nehalem is Rack 2's x64 standard.
4. **`_USE_MATH_DEFINES`** — MinGW `<cmath>` hides `M_PI`/`M_SQRT2` under strict `-std=c++17`, breaking the Rack SDK headers.
5. **`file(TO_CMAKE_PATH ...)` on the install dir** — `%APPDATA%`/`%LOCALAPPDATA%` backslashes were read as escapes (`\U`) and broke `install(DIRECTORY res/)` under CMP0177.

### Verification
- `objdump -x plugin.dll` after the fix imports only `libRack.dll`, `KERNEL32.dll`, `msvcrt.dll`, `WS2_32.dll` — no MinGW runtime DLLs.
- Rack logs `Loaded plugin VCVRackMcpServer 2.1.1` (previously `code 127`).
- HTTP bridge live: `GET :2600/status` → `{"status":"ok","moduleCount":1}`; MCP client connects.

Tested on Windows 11, VCV Rack Free 2.6.6, MSYS2 gcc 16.1.0.